### PR TITLE
Use `--` in case file shares name w/ref

### DIFF
--- a/git-ls
+++ b/git-ls
@@ -103,7 +103,7 @@ do
 
     if echo "$comitted" | grep -Fxq "$file"
     then
-        log="$(git log -1 --pretty="format:%cr"$'\t'"%H"$'\t'"%s" "$file")"
+        log="$(git log -1 --pretty="format:%cr"$'\t'"%H"$'\t'"%s" -- "$file")"
 
         if [ "$formatting" -eq 0 ]
         then


### PR DESCRIPTION
If `$file` is the name of a file and of a ref (say, a branch name), then `git log` aborts.  Specifying `--` disambiguates.
